### PR TITLE
fix for blu bug

### DIFF
--- a/create-card.js
+++ b/create-card.js
@@ -293,7 +293,12 @@ class CardCreator {
     // Name, Title, Server Rect
     ctx.fillRect(25, 10, 840, 100);
 
-    ctx.drawImage(this.imgJobBg[data.Character.ActiveClassJob.UnlockedState.ID], 450, 4, rectFullWidth, 110);
+    // BLU returns a null UnlockedState.ID so we can't use it to pick the job image.
+    if (data.Character.ActiveClassJob.UnlockedState.ID != null) {
+      ctx.drawImage(this.imgJobBg[data.Character.ActiveClassJob.UnlockedState.ID], 450, 4, rectFullWidth, 110);
+    } else {
+      ctx.drawImage(this.imgJobBg[36], 450, 4, rectFullWidth, 110);
+    }
 
     ctx.fillRect(rectStartX, rectStartRow2Y, rectHalfWidth, rectHeightRow2);
     ctx.fillRect(rectStartXHalf, rectStartRow2Y, rectHalfWidth, rectHeightRow2);


### PR DESCRIPTION
Blue Mage returns ``null`` for ``UnlockedState.ID`` which causes any players who are playing BLU mage at the time of lodestone snapshots to not receive cards. There might be a better way to handle this but this is what I threw together really fast when I had a spare moment this weekend.