### PR TITLE
Fix ilvl calculation

### DIFF
--- a/create-card.js
+++ b/create-card.js
@@ -265,7 +265,10 @@ class CardCreator {
     if (cnt == 0)
       return 0;
 
-    return this.pad(Math.floor(ilvl / cnt), 4);
+    // ilvl division is always out of 13 items
+    // mainhand counts twice if there's no offhand
+    // job stones are ignored
+    return this.pad(Math.floor(ilvl / 13), 4);
   }
 
   pad(num, size) {


### PR DESCRIPTION
Empty slots are not ignored for ilvl, the divisor is always fixed at 13. Magic numbers suck but here we are.

A further TODO (I'll make a GH issue), some items should be collected into a map for ID's to override the ilvl to 1, such as the experience gain earrings.